### PR TITLE
feat(`run` command): Add a `port` option and search for the first free port >= 3000 by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "listr": "^0.14.3",
         "listr-silent-renderer": "^1.1.1",
         "lodash-es": "^4.17.21",
+        "portfinder": "^1.0.28",
         "prettier": "^2.5.1",
         "prettier-plugin-import-sort": "^0.0.7",
         "resolve-cwd": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "listr": "^0.14.3",
     "listr-silent-renderer": "^1.1.1",
     "lodash-es": "^4.17.21",
+    "portfinder": "^1.0.28",
     "prettier": "^2.5.1",
     "prettier-plugin-import-sort": "^0.0.7",
     "resolve-cwd": "^3.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,13 +84,19 @@ export const argv = yargs(hideBin(process.argv))
   )
 
   .command(
-    "run [experiment-file]",
+    "run [experiment-file] [options]",
     "Build the specified experiment, start a local development server, and watch for " +
       "changes to the source files. " +
       "Once a source file is modified, update the build and any browser window " +
       "running the experiment.",
-    (yargsBuilder) => addExperimentFileOption(yargsBuilder),
-    ({ experimentFile }) => handleErrors(() => commands.run(experimentFile as string))
+    (yargsBuilder) =>
+      addExperimentFileOption(yargsBuilder).option("port", {
+        alias: "p",
+        type: "number",
+        description: "The port that the development server should listen on.",
+        defaultDescription: "the smallest port number >= 3000 available",
+      }),
+    ({ experimentFile, port }) => handleErrors(() => commands.run(experimentFile, port))
   )
 
   .command(
@@ -106,8 +112,7 @@ export const argv = yargs(hideBin(process.argv))
           "Package the experiment for JATOS. " +
           "The resulting jzip file can then be imported as a JATOS study by JATOS.",
       }),
-    ({ experimentFile, jatos }) =>
-      handleErrors(() => commands.build(experimentFile as string, jatos))
+    ({ experimentFile, jatos }) => handleErrors(() => commands.build(experimentFile, jatos))
   )
 
   .completion(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -47,7 +47,7 @@ export async function build(experiment: string, isForJatos = false) {
   console.log(context.message);
 }
 
-export async function run(experiment: string) {
+export async function run(experiment: string, port?: number) {
   const ctx = await new Listr([
     { ...tasks.build, title: `Building ${experiment}` },
     tasks.webpackDevServer,
@@ -55,6 +55,7 @@ export async function run(experiment: string) {
     experiment,
     isProduction: false,
     isForJatos: false,
+    devServerPort: port,
   });
   console.log(ctx.message);
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -12,6 +12,7 @@ import gulpTemplate from "gulp-template";
 import gulpZip from "gulp-zip";
 import { ListrTask } from "listr";
 import { mergeWith, sortedUniq } from "lodash-es";
+import portFinder from "portfinder";
 import resolveCwd from "resolve-cwd";
 import { Observable } from "rxjs";
 import webpack, { Compiler } from "webpack";
@@ -72,6 +73,8 @@ export interface BuilderContext {
 
   isForJatos?: boolean;
   isProduction?: boolean;
+
+  devServerPort?: number;
 
   compiler?: Compiler;
   devServer?: WebpackDevServer;
@@ -227,15 +230,16 @@ export const build: ListrTask<BuilderContext> = {
 export const webpackDevServer: ListrTask<BuilderContext> = {
   title: "Starting development server",
   task: async (ctx) => {
+    if (!ctx.devServerPort) {
+      ctx.devServerPort = await portFinder.getPortPromise({ port: 3000 });
+    }
+
     const devServer = new WebpackDevServer(
       {
         static: {
           directory: distPath,
         },
-        devMiddleware: {
-          publicPath: "http://localhost:3000/",
-        },
-        port: 3000,
+        port: ctx.devServerPort,
         client: {
           overlay: true,
         },


### PR DESCRIPTION
`port: "auto",` starts at 8080, so this uses `portfinder` instead to find a port >= 3000.

Closes #19